### PR TITLE
MANTA-4629 add Jenkinsfiles to Manta repositories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,63 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+@Library('jenkins-joylib@v1.0.2') _
+
+pipeline {
+
+    agent {
+        label joyCommonLabels(image_ver: '1.6.3', pkgsrc_arch: 'i386')
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '30'))
+        timestamps()
+    }
+
+    stages {
+        stage('check') {
+            steps{
+                sh('make check')
+            }
+        }
+        // avoid bundling devDependencies
+        stage('re-clean') {
+            steps {
+                sh('git clean -fdx')
+            }
+        }
+        stage('build image and upload') {
+            steps {
+                sh('''
+set -o errexit
+set -o pipefail
+
+export ENGBLD_BITS_UPLOAD_IMGAPI=true
+make print-BRANCH print-STAMP all release publish bits-upload''')
+            }
+        }
+        stage('mako') {
+            // TODO: Consider complex handling of multiple branches
+            when {
+                branch 'master'
+            }
+            steps {
+                build(job:'mako', wait: false)
+            }
+        }
+    }
+
+    post {
+        always {
+            joyMattermostNotification(channel: 'jenkins')
+        }
+    }
+
+}


### PR DESCRIPTION
This PR has similar requirements to our agentshar changes, in that we have traditionally had a downstream job that builds 'mola' when this changes. As of now, there's no logic here to try to do a mola job with the same $BRANCH as this job, falling back to master, if no such branch exists.
I'd hope to investigate that along with the agents->agentsshar thing, because I suspect they'll use the same mechanism.